### PR TITLE
Feature/optional image quality

### DIFF
--- a/annotationweb/forms.py
+++ b/annotationweb/forms.py
@@ -11,7 +11,8 @@ class TaskForm(forms.ModelForm):
     class Meta:
         model = Task
         fields = ['name', 'dataset', 'show_entire_sequence', 'frames_before',
-                  'frames_after', 'auto_play', 'user_frame_selection', 'annotate_single_frame', 'shuffle_videos', 'type', 'label', 'user', 'description']
+                  'frames_after', 'auto_play', 'user_frame_selection', 'annotate_single_frame', 'shuffle_videos',
+                  'image_quality', 'type', 'label', 'user', 'description']
 
     # def clean(self):
     #     cleaned_data = super(TaskForm, self).clean()
@@ -103,3 +104,10 @@ class ImageListForm(forms.Form):
                 widget=forms.SelectMultiple(attrs={'onchange': 'this.form.submit();'})
             )
 
+        # if data['image_quality'] != ImageAnnotation.QUALITY_UNK:
+        #     self.fields['image_quality'] = forms.MultipleChoiceField(
+        #         label='Image quality',
+        #         choices=ImageAnnotation.IMAGE_QUALITY_CHOICES,
+        #         initial=[x for x, y in ImageAnnotation.IMAGE_QUALITY_CHOICES],
+        #         widget=forms.SelectMultiple(attrs={'onchange': 'this.form.submit();'})
+        #     )

--- a/annotationweb/models.py
+++ b/annotationweb/models.py
@@ -73,6 +73,7 @@ class Task(models.Model):
            help_text='<button onclick="'
                      'window.open(\'/new-label/\', \'Add new label\', \'width=400,height=400,scrollbars=no\');"'
                      ' type="button">Add new label</button>')
+    image_quality = models.BooleanField(help_text='Request image quality evaluation', default=True)
     user = models.ManyToManyField(User)
     description = models.TextField(default='', blank=True)
     large_image_layout = models.BooleanField(default=False, help_text='Use a large image layout for annotation')
@@ -128,12 +129,13 @@ class ImageAnnotation(models.Model):
     QUALITY_POOR = 'poor'
     QUALITY_OK = 'ok'
     QUALITY_GOOD = 'good'
+    QUALITY_UNK = 'unknown'
     IMAGE_QUALITY_CHOICES = (
         (QUALITY_POOR, 'Poor'),
         (QUALITY_OK, 'OK'),
         (QUALITY_GOOD, 'Good'),
     )
-    image_quality = models.CharField(max_length=50, choices=IMAGE_QUALITY_CHOICES)
+    image_quality = models.CharField(max_length=50, choices=IMAGE_QUALITY_CHOICES, default=QUALITY_UNK)
     comments = models.TextField()
     rejected = models.BooleanField()
     finished = models.BooleanField(default=True)

--- a/annotationweb/models.py
+++ b/annotationweb/models.py
@@ -134,6 +134,7 @@ class ImageAnnotation(models.Model):
         (QUALITY_POOR, 'Poor'),
         (QUALITY_OK, 'OK'),
         (QUALITY_GOOD, 'Good'),
+        (QUALITY_UNK, 'Unknown'),
     )
     image_quality = models.CharField(max_length=50, choices=IMAGE_QUALITY_CHOICES, default=QUALITY_UNK)
     comments = models.TextField()

--- a/annotationweb/settings.py
+++ b/annotationweb/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # python manage.py shell -c 'from django.core.management import utils; print(utils.get_random_secret_key())'
 # You can safely change this at any time, but note that logged in users will be logged out.
 # See more info here: https://medium.com/@bayraktar.eralp/changing-rotating-django-secret-key-without-logging-users-out-804a29d3ea65
-#SECRET_KEY = 'insert secret key here!'
+SECRET_KEY = 'insert secret key here!'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/annotationweb/templates/annotationweb/do_task.html
+++ b/annotationweb/templates/annotationweb/do_task.html
@@ -77,14 +77,18 @@ setReturnURL('{{ return_url|safe }}');
     Do you wish to save the changes before going to the next/previous image?
 </div>
 <h3>Annotation</h3>
-<div id="imageQuality">
-<form id="imageQualityForm">
-    Image quality:
-    {% for quality_id, quality_name in image_quality_choices %}
-    <input type="radio" name="quality" value="{{ quality_id }}" required{% if chosen_quality == quality_id %} checked="checked"{% endif %}> {{ quality_name }}
-    {% endfor %}
-</form>
-</div>
+{% if task.image_quality %}
+    <div id="imageQuality">
+        <form id="imageQualityForm">
+            Image quality:
+            {% for quality_id, quality_name in image_quality_choices %}
+                {% if quality_id != 'unknown' %}
+                    <input type="radio" name="quality" value="{{ quality_id }}" required{% if chosen_quality == quality_id %} checked="checked"{% endif %}> {{ quality_name }}
+                {% endif %}
+            {% endfor %}
+        </form>
+    </div>
+{%  endif %}
 
 {%  block CopyContentButton %}
 {%  endblock CopyContentButton%}

--- a/annotationweb/templates/annotationweb/task.html
+++ b/annotationweb/templates/annotationweb/task.html
@@ -47,8 +47,11 @@
         {% if task.annotate_single_frame %}
         Date: {{ image.annotation.date|date:"d-m-Y H:i" }}<br>
         User: {{ image.annotation.user.username }}<br>
-        Image quality: {{ image.annotation.image_quality }}<br>
-
+        
+        {% if task.image_quality %}
+            Image quality: {{ image.annotation.image_quality }}<br>
+        {% endif %}
+        
         {% if task.type == 'classification' %}
             {# Get all labels if task is classification task #}
             {% for frame in image.annotation_frames %}

--- a/common/task.py
+++ b/common/task.py
@@ -289,15 +289,16 @@ def save_annotation(request):
         if request.method != 'POST':
             raise Exception('ERROR: Must use POST when saving processed image.')
 
-        # Image quality is required
-        if 'quality' not in request.POST:
-            raise Exception('ERROR: You must select image quality.')
 
         image_id = int(request.POST['image_id'])
         task_id = int(request.POST['task_id'])
         new_key_frames = json.loads(request.POST['target_frames'])
         rejected = request.POST['rejected'] == 'true'
         comments = request.POST['comments']
+
+        # Image quality is required
+        if (Task.objects.get(task_id=task_id).image_quality) and ('quality' not in request.POST):
+            raise Exception('ERROR: You must select image quality.')
 
         # Delete old key frames if they exist, this will also delete old annotations
         key_frames = KeyFrameAnnotation.objects.filter(image_annotation__task_id=task_id, image_annotation__image_id=image_id)
@@ -315,7 +316,8 @@ def save_annotation(request):
         annotation.comments = comments
         annotation.user = request.user
         annotation.finished = True
-        annotation.image_quality = request.POST['quality']
+        if Task.objects.get(task_id=task_id).image_quality:
+            annotation.image_quality = request.POST['quality']
         annotation.save()
 
         annotations = []

--- a/common/task.py
+++ b/common/task.py
@@ -297,7 +297,7 @@ def save_annotation(request):
         comments = request.POST['comments']
 
         # Image quality is required
-        if (Task.objects.get(task_id=task_id).image_quality) and ('quality' not in request.POST):
+        if Task.objects.get(id=task_id).image_quality and ('quality' not in request.POST):
             raise Exception('ERROR: You must select image quality.')
 
         # Delete old key frames if they exist, this will also delete old annotations
@@ -316,7 +316,7 @@ def save_annotation(request):
         annotation.comments = comments
         annotation.user = request.user
         annotation.finished = True
-        if Task.objects.get(task_id=task_id).image_quality:
+        if Task.objects.get(id=task_id).image_quality:
             annotation.image_quality = request.POST['quality']
         annotation.save()
 


### PR DESCRIPTION
Made it available for admin users to optionally collect image quality assessment. By default, this field will have an 'unknown' value.
The 'unknown' option is hidden in the front-end, only showing the original 'ok', 'god', and 'poor' options.